### PR TITLE
Fix Jenkins version / build number, Added permissions

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: SurvivalGames
-version: {PROJECT.VERSION}.${build.version}
+version: ${project.version}.${build.version}
 main: org.mcsg.survivalgames.SurvivalGames
 authors: [Double0negative]
 description: Fully Automated Hunger Games Plugin!
@@ -10,3 +10,103 @@ commands:
         usage: /sg <command> <args>
         aliases: [sg, hungergames, hg]
 
+permissions:
+    sg.player.*:
+        default: true
+        description: SurvivalGames Player Commands
+        children:
+            sg.player.play: true
+            sg.player.vote: true
+            sg.player.spectate: true
+            sg.player.join: true
+            sg.player.leave: true
+            sg.player.sponsor: true
+            sg.player.listarenas: true
+            sg.player.leavequeue: true
+    sg.player.play:
+        description: Allows the user to click a sign to join a game.
+        default: true
+    sg.player.vote:
+        description: Allows the user to vote to start a game.
+        default: true
+    sg.player.spectate:
+        description:  Allows the user to spectate a game.
+        default: true
+    sg.player.join:
+        description: Allows the use of /sg join to join the lobby.
+        default: true
+    sg.player.leave:
+        description: Allows the use of /sg leave to leave a game.
+        default: true
+    sg.player.sponsor:
+        description: Sponsor a player!
+        default: true
+    sg.player.listarenas:
+        description: List all arenas set up.
+        default: true
+    sg.player.list:
+        description: List all players in the arena you are playing in.
+        default: true
+    sg.player.leavequeue:
+        description: Allows the use of /sg lq to leave the queue for any queued games
+        default: true
+
+    sg.staff.*:
+        default: op
+        description: SurvivalGames Staff Commands
+        children:
+            sg.player.*: true
+            sg.staff.forcestart: true
+            sg.staff.disablearena: true
+            sg.staff.enablearena: true
+            sg.staff.nocmdblock: true
+    sg.staff.forcestart:
+        description: Allows the user to force start a game.
+        default: op
+    sg.staff.disablearena:
+        description: Allows the user to disable an arena.
+        default: op
+    sg.staff.enablearena:
+        description: Allows the user to enable an arena.
+        default: op
+    sg.staff.nocmdblock:
+        description: Allows user to bypass in-game command block.
+        default: op
+        
+    sg.admin.*:
+        default: op
+        description: SurvivalGames Admin Commands.
+        children:
+            sg.staff.*: true
+            sg.admin.createarena: true
+            sg.admin.setarenaspawns: true
+            sg.admin.resetspawns: true
+            sg.admin.deletearena: true
+            sg.admin.setlobby: true
+            sg.admin.flag: true
+            sg.arena.teleport: true
+    sg.admin.createarena:
+        description: Allows the user to create an arena.
+        default: op
+    sg.admin.setarenaspawns:
+        description: Allows user to set arena spawns.
+        default: op
+    sg.admin.resetspawns:
+        description: Allows the user to reset all spawnpoints.
+        default: op
+    sg.admin.deletearena:
+        description: Allows a user to delete an arena.
+        default: op
+    sg.admin.setlobby:
+        description: Allows the user to set the lobby spawn and wall.
+        default: op
+    sg.admin.flag:
+        description: Allows the user to modify per-arena flags.
+        default: op
+    sg.admin.statswall:
+        description: Allows the user to set the stats wall.
+        default: op
+    	
+    sg.arena.teleport:
+        description: Allows the user to teleport to an arena.
+        default: op

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: SurvivalGames
-version: ${project.version}.${build.version}
+version: ${project.version}.${BUILD_NUMBER}
 main: org.mcsg.survivalgames.SurvivalGames
 authors: [Double0negative]
 description: Fully Automated Hunger Games Plugin!


### PR DESCRIPTION
Fixed the {PROJECT.VERSION}.${build.version} to ${project.version}.${build.version}
Your last build (#25) on the CI failed to add the version and build number.

Added all permissions with description.

One question, why does the Teleport has a different permission? (sg.arena.teleport)
