### PR TITLE
Mojang Official Enchantment name compatiblity

### DIFF
--- a/src/main/java/org/mcsg/survivalgames/util/ItemReader.java
+++ b/src/main/java/org/mcsg/survivalgames/util/ItemReader.java
@@ -34,8 +34,8 @@ public class ItemReader {
 		encids.put("fireprotection", Enchantment.PROTECTION_FIRE);
 		encids.put("featherfall", Enchantment.PROTECTION_FALL);
 		encids.put("featherfalling", Enchantment.PROTECTION_FALL);
-		encids.put("blastprot", Enchantment.PROTECTION_EXPLOSION);
-		encids.put("blastprotection", Enchantment.PROTECTION_EXPLOSION);
+		encids.put("blastprot", Enchantment.PROTECTION_EXPLOSIONS);
+		encids.put("blastprotection", Enchantment.PROTECTION_EXPLOSIONS);
 		encids.put("projectileprot", Enchantment.PROTECTION_PROJECTILE);
 		encids.put("projectileprotection", Enchantment.PROTECTION_PROJECTILE);
 		encids.put("aquaaffinity", Enchantment.WATER_WORKER);
@@ -43,7 +43,7 @@ public class ItemReader {
 		
 		//Weapon Enchants
 		encids.put("smite", Enchantment.DAMAGE_UNDEAD);
-		encids.put("baneofarthropods", Enchantment.DAMAGE_ARTHROPODS)
+		encids.put("baneofarthropods", Enchantment.DAMAGE_ARTHROPODS);
 		encids.put("sharpness", Enchantment.DAMAGE_ALL);
 		encids.put("dmg", Enchantment.DAMAGE_ALL);
 		encids.put("fire", Enchantment.FIRE_ASPECT);

--- a/src/main/java/org/mcsg/survivalgames/util/ItemReader.java
+++ b/src/main/java/org/mcsg/survivalgames/util/ItemReader.java
@@ -52,11 +52,13 @@ public class ItemReader {
 			return new ItemStack(Integer.parseInt(split[0]), Integer.parseInt(split[1]), Short.parseShort(split[2]));
 		}else{
 			ItemStack i =  new ItemStack(Integer.parseInt(split[0]), Integer.parseInt(split[1]), Short.parseShort(split[2]));
-			String encs[] = split[3].split(" ");
-			for(String enc: encs){
-				System.out.println(enc);
-				String e[] = enc.split(":");
-				i.addUnsafeEnchantment(encids.get(e[0]), Integer.parseInt(e[1]));
+			if (!split[3].equalsIgnoreCase("none")) {
+				String encs[] = split[3].split(" ");
+				for(String enc: encs){
+					System.out.println(enc);
+					String e[] = enc.split(":");
+					i.addUnsafeEnchantment(encids.get(e[0]), Integer.parseInt(e[1]));
+				}
 			}
 			if(split.length == 5){
 				ItemMeta im = i.getItemMeta();

--- a/src/main/java/org/mcsg/survivalgames/util/ItemReader.java
+++ b/src/main/java/org/mcsg/survivalgames/util/ItemReader.java
@@ -60,7 +60,7 @@ public class ItemReader {
 		encids.put("power", Enchantment.ARROW_DAMAGE);
 		encids.put("infinity", Enchantment.ARROW_INFINITE);
 		encids.put("flame", Enchantment.ARROW_FIRE);
-
+		
 	}
 	
 	
@@ -72,7 +72,7 @@ public class ItemReader {
 		String split[] = str.split(",");
 		SurvivalGames.debug("ItemReader: reading : "+Arrays.toString(split));
 		for(int a = 0; a < split.length; a++){
-			split[a] = split[a].toLowerCase().trim();
+			split[a] = split[a].trim();
 		}
 		if(split.length < 1){
 			return null;
@@ -85,7 +85,7 @@ public class ItemReader {
 		}else{
 			ItemStack i =  new ItemStack(Integer.parseInt(split[0]), Integer.parseInt(split[1]), Short.parseShort(split[2]));
 			if (!split[3].equalsIgnoreCase("none")) {
-				String encs[] = split[3].split(" ");
+				String encs[] = split[3].toLowerCase().split(" ");
 				for(String enc: encs){
 					System.out.println(enc);
 					String e[] = enc.split(":");

--- a/src/main/java/org/mcsg/survivalgames/util/ItemReader.java
+++ b/src/main/java/org/mcsg/survivalgames/util/ItemReader.java
@@ -24,10 +24,42 @@ public class ItemReader {
 			encids.put(e.toString().toLowerCase().replace("_", ""), e);
 		}
 		
+		//Anything enchants
+		encids.put("unbreaking", Enchantment.DURABILITY);
 		
+		//Armor Enchants
+		encids.put("prot", Enchantment.PROTECTION_ENVIRONMENTAL);
+		encids.put("protection", Enchantment.PROTECTION_ENVIRONMENTAL);
+		encids.put("fireprot", Enchantment.PROTECTION_FIRE);
+		encids.put("fireprotection", Enchantment.PROTECTION_FIRE);
+		encids.put("featherfall", Enchantment.PROTECTION_FALL);
+		encids.put("featherfalling", Enchantment.PROTECTION_FALL);
+		encids.put("blastprot", Enchantment.PROTECTION_EXPLOSION);
+		encids.put("blastprotection", Enchantment.PROTECTION_EXPLOSION);
+		encids.put("projectileprot", Enchantment.PROTECTION_PROJECTILE);
+		encids.put("projectileprotection", Enchantment.PROTECTION_PROJECTILE);
+		encids.put("aquaaffinity", Enchantment.WATER_WORKER);
+		encids.put("respiration", Enchantment.OXYGEN);
+		
+		//Weapon Enchants
+		encids.put("smite", Enchantment.DAMAGE_UNDEAD);
+		encids.put("baneofarthropods", Enchantment.DAMAGE_ARTHROPODS)
 		encids.put("sharpness", Enchantment.DAMAGE_ALL);
 		encids.put("dmg", Enchantment.DAMAGE_ALL);
 		encids.put("fire", Enchantment.FIRE_ASPECT);
+		encids.put("looting", Enchantment.LOOT_BONUS_MOBS);
+		encids.put("loot", Enchantment.LOOT_BONUS_MOBS);
+		
+		//Tool enchants (Silk Touch's enchantment name is Silk_Touch, so it's covered above)
+		encids.put("efficiency", Enchantment.DIG_SPEED);
+		encids.put("fort", Enchantment.LOOT_BONUS_BLOCKS);
+		encids.put("fortune", Enchantment.LOOT_BONUS_BLOCKS);
+		
+		//Bow specific enchants
+		encids.put("punch", Enchantment.ARROW_KNOCKBACK);
+		encids.put("power", Enchantment.ARROW_DAMAGE);
+		encids.put("infinity", Enchantment.ARROW_INFINITE);
+		encids.put("flame", Enchantment.ARROW_FIRE);
 
 	}
 	


### PR DESCRIPTION
Adds functionality to write ItemReader statements using the official enchantment names issued by Mojang. Also adds the ability to name items without enchanting by specifying "none" in the enchantment section of any ItemReader statement.

Side note: It honestly took me around 4 hours today to realize that this never used the official Mojang names, I had thought I was doing something wrong in my kits.yml ...
