### PR TITLE
Fixes "help" listing

### DIFF
--- a/src/main/java/org/mcsg/survivalgames/commands/ForceStart.java
+++ b/src/main/java/org/mcsg/survivalgames/commands/ForceStart.java
@@ -55,7 +55,7 @@ public class ForceStart implements SubCommand {
 
 	@Override
 	public String help(Player p) {
-		return "/sg forcestart - " + SettingsManager.getInstance().getMessageConfig().getString("messages.help.forcestart", "Forces the game to start");
+		return "/sg start - " + SettingsManager.getInstance().getMessageConfig().getString("messages.help.forcestart", "Forces the game to start");
 	}
 
 	@Override


### PR DESCRIPTION
Says the command is /sg forcestart in /sg help, is actually /sg start
