### PR TITLE
Fixed GameManager 'isPlayerInactive' function to return correct value.

### DIFF
--- a/src/main/java/org/mcsg/survivalgames/GameManager.java
+++ b/src/main/java/org/mcsg/survivalgames/GameManager.java
@@ -128,7 +128,7 @@ public class GameManager {
 
 	public boolean isPlayerInactive(Player player) {
 		for (Game g: games) {
-			if (g.isPlayerActive(player)) {
+			if (g.isPlayerInactive(player)) {
 				return true;
 			}
 		}


### PR DESCRIPTION
The `isPlayerActive(Player player)` function in the GameManager class was returning true when a player was active, rather than inactive. It now returns the correct value.
