### PR TITLE
ChestRatioStorage fix for multiple levels in chest.yml

### DIFF
--- a/src/main/java/org/mcsg/survivalgames/SurvivalGames.java
+++ b/src/main/java/org/mcsg/survivalgames/SurvivalGames.java
@@ -36,7 +36,7 @@ public class SurvivalGames extends JavaPlugin {
 	public static List < String > auth = Arrays.asList(new String[] {
 			"Double0negative", "iMalo", "Medic0987", "alex_markey", "skitscape", "AntVenom", "YoshiGenius", "pimpinpsp", "WinryR", "Jazed2011",
 			"KiwiPantz", "blackracoon", "CuppingCakes", "4rr0ws", "Fawdz", "Timothy13", "rich91", "ModernPrestige", "Snowpool", "egoshk", 
-			"nickm140",  "chaseoes", "Oceangrass", "GrailMore", "iAngelic", "Lexonia", "ChaskyT", "Anon232"
+			"nickm140",  "chaseoes", "Oceangrass", "GrailMore", "iAngelic", "Lexonia", "ChaskyT", "Anon232", "IngeniousGamer" //:) -Bryce
 	});
 
 	SurvivalGames p = this;

--- a/src/main/java/org/mcsg/survivalgames/util/ChestRatioStorage.java
+++ b/src/main/java/org/mcsg/survivalgames/util/ChestRatioStorage.java
@@ -32,14 +32,14 @@ public class ChestRatioStorage {
 			ArrayList<ItemStack> lvl = new ArrayList<ItemStack>();
 			List<String>list = conf.getStringList("chest.lvl"+clevel);
 
-			if(list != null){
+			if(!list.isEmpty()){
 				for(int b = 0; b<list.size();b++){
 					ItemStack i = ItemReader.read(list.get(b));
 					lvl.add(i);
 				}
 				lvlstore.put(clevel, lvl);
 			} else {
-				maxlevel = clevel;
+				maxlevel = clevel-1;
 				break;
 			}
 		}

--- a/src/main/resources/chest.yml
+++ b/src/main/resources/chest.yml
@@ -12,7 +12,7 @@
 version: 0
 
 chest:
-  ratio: 2
+  ratio: 10
   lvl1:
   - 268,1
   - 298,1


### PR DESCRIPTION
Requires a higher ratio set in the chest.yml config - new default value: 10
-added meh name in VIP names >_>(shh)
