### PR TITLE
Adds Event for Player Actually entering the arena

### DIFF
--- a/src/main/java/org/mcsg/survivalgames/Game.java
+++ b/src/main/java/org/mcsg/survivalgames/Game.java
@@ -14,6 +14,7 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.plugin.Plugin;
 import org.mcsg.survivalgames.MessageManager.PrefixType;
+import org.mcsg.survivalgames.api.PlayerEnterArenaEvent;
 import org.mcsg.survivalgames.api.PlayerJoinArenaEvent;
 import org.mcsg.survivalgames.api.PlayerKilledEvent;
 import org.mcsg.survivalgames.api.PlayerLeaveArenaEvent;
@@ -243,6 +244,8 @@ public class Game {
 						showMenu(p);
 						HookManager.getInstance().runHook("GAME_POST_ADDPLAYER", "activePlayers-"+activePlayers.size());
 
+						Bukkit.getServer().getPluginManager().callEvent(new PlayerEnterArenaEvent(p, GameManager.getInstance().getGame(gameID)));
+						
 						if(spawnCount == activePlayers.size()){
 							countdown(5);
 						}

--- a/src/main/java/org/mcsg/survivalgames/api/PlayerEnterArenaEvent.java
+++ b/src/main/java/org/mcsg/survivalgames/api/PlayerEnterArenaEvent.java
@@ -1,0 +1,50 @@
+package org.mcsg.survivalgames.api;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.HandlerList;
+
+import org.bukkit.event.Event;
+import org.mcsg.survivalgames.Game;
+
+public class PlayerEnterArenaEvent extends Event implements Cancellable {
+
+	private static final HandlerList handlers = new HandlerList();
+    private Player player;
+    private Game game;
+    private boolean cancelled = false;
+    
+	public PlayerEnterArenaEvent(Player p, Game game) {
+		this.player = p;
+		this.game = game;
+	}
+	
+	public Player getPlayer()
+	{
+		return this.player;
+	}
+
+	public Game getGame()
+	{
+		return this.game;
+	}
+	
+	public HandlerList getHandlers() {
+		return handlers;
+	}
+	 
+	public static HandlerList getHandlerList() {
+	   return handlers;
+	}
+
+	@Override
+	public boolean isCancelled() {
+		return cancelled;
+	}
+
+	@Override
+	public void setCancelled(boolean arg0) {
+		cancelled = arg0;
+	}
+
+}


### PR DESCRIPTION
The Existing PlayerJoinAreaEvent fires as soon as the player clicks the
sign to join. This event doesn't fire until the player is teleported to
the arena world.

This is useful for plugin that override the default Survival Games Kits system.
